### PR TITLE
Use community recommendations on knowledge pages

### DIFF
--- a/src/pages/knowledge/AdventuresPage.tsx
+++ b/src/pages/knowledge/AdventuresPage.tsx
@@ -1,33 +1,18 @@
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { FileText, Map } from 'lucide-react';
-import { ArticleSubmissionDialog } from '@/components/knowledge/ArticleSubmissionDialog';
-import { CategoryArticlesList } from '@/components/admin/CategoryArticlesList';
+import { CommunityRecommendationsList } from '@/components/knowledge/CommunityRecommendationsList';
+import { RecommendationSubmissionDialog } from '@/components/knowledge/RecommendationSubmissionDialog';
 import { KnowledgeNavigation } from '@/components/knowledge/KnowledgeNavigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProfile } from '@/hooks/profile';
-import { supabase } from '@/lib/supabase-client';
 
 const AdventuresPage = () => {
   const [submissionDialogOpen, setSubmissionDialogOpen] = useState(false);
   const { user } = useAuth();
   const { userData } = useProfile();
-  const [isAdmin, setIsAdmin] = useState(false);
-  
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (user) {
-        const { data } = await supabase.rpc("has_role", {
-          _role: "admin",
-        });
-        setIsAdmin(!!data);
-      }
-    };
-    
-    checkAdminStatus();
-  }, [user]);
   
   // Prepare user data for Layout with proper avatar logic
   const layoutUser = userData ? {
@@ -55,18 +40,15 @@ const AdventuresPage = () => {
           </div>
           <Button onClick={() => setSubmissionDialogOpen(true)}>
             <FileText className="mr-2 h-4 w-4" />
-            Submit Adventure Article
+            Submit Adventure Recommendation
           </Button>
         </div>
         
         <KnowledgeNavigation />
         
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Community Adventure Articles</h2>
-          <CategoryArticlesList 
-            category="Adventures"
-            isAdmin={isAdmin}
-          />
+          <h2 className="text-2xl font-semibold mb-4">Community Adventure Recommendations</h2>
+          <CommunityRecommendationsList category="Adventures" />
         </div>
         
         <div className="mb-8">
@@ -76,16 +58,15 @@ const AdventuresPage = () => {
             <h3 className="text-xl font-medium mb-2">Coming Soon</h3>
             <p className="text-muted-foreground mb-4 max-w-lg mx-auto">
               We're mapping out some of the most exciting Unimog adventure routes around the world.
-              In the meantime, check out the community articles above.
+              In the meantime, check out the community recommendations above.
             </p>
           </div>
         </div>
         
-        {/* Article Submission Dialog */}
-        <ArticleSubmissionDialog
+        {/* Recommendation Submission Dialog */}
+        <RecommendationSubmissionDialog
           open={submissionDialogOpen}
           onOpenChange={setSubmissionDialogOpen}
-          category="Adventures"
         />
       </div>
     </Layout>

--- a/src/pages/knowledge/MaintenancePage.tsx
+++ b/src/pages/knowledge/MaintenancePage.tsx
@@ -1,31 +1,19 @@
 
 // Import needed components
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { FileText, Wrench } from 'lucide-react';
+import { CommunityRecommendationsList } from '@/components/knowledge/CommunityRecommendationsList';
+import { RecommendationSubmissionDialog } from '@/components/knowledge/RecommendationSubmissionDialog';
 import { KnowledgeNavigation } from '@/components/knowledge/KnowledgeNavigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProfile } from '@/hooks/profile';
-import { supabase } from '@/lib/supabase-client';
 
 const MaintenancePage = () => {
   const { user } = useAuth();
   const { userData } = useProfile();
-  const [isAdmin, setIsAdmin] = useState(false);
-  
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (user) {
-        const { data } = await supabase.rpc("has_role", {
-          _role: "admin",
-        });
-        setIsAdmin(!!data);
-      }
-    };
-    
-    checkAdminStatus();
-  }, [user]);
+  const [submissionDialogOpen, setSubmissionDialogOpen] = useState(false);
   
   // Prepare user data for Layout with proper avatar logic
   const layoutUser = userData ? {
@@ -51,11 +39,19 @@ const MaintenancePage = () => {
               Regular maintenance guides and tips to keep your Unimog in top condition.
             </p>
           </div>
+          <Button onClick={() => setSubmissionDialogOpen(true)}>
+            <FileText className="mr-2 h-4 w-4" />
+            Submit Maintenance Recommendation
+          </Button>
         </div>
         
         <KnowledgeNavigation />
-        
-        
+
+        <div className="mb-8">
+          <h2 className="text-2xl font-semibold mb-4">Community Maintenance Recommendations</h2>
+          <CommunityRecommendationsList category="Maintenance" />
+        </div>
+
         <div className="mb-8">
           <h2 className="text-2xl font-semibold mb-4">Maintenance Schedules</h2>
           <div className="bg-muted rounded-lg p-8 text-center">
@@ -63,11 +59,16 @@ const MaintenancePage = () => {
             <h3 className="text-xl font-medium mb-2">Coming Soon</h3>
             <p className="text-muted-foreground mb-4 max-w-lg mx-auto">
               We're developing detailed maintenance schedules for various Unimog models.
-              In the meantime, check out the community articles above.
+              In the meantime, check out the community recommendations above.
             </p>
           </div>
         </div>
         
+        {/* Recommendation Submission Dialog */}
+        <RecommendationSubmissionDialog
+          open={submissionDialogOpen}
+          onOpenChange={setSubmissionDialogOpen}
+        />
       </div>
     </Layout>
   );

--- a/src/pages/knowledge/ModificationsPage.tsx
+++ b/src/pages/knowledge/ModificationsPage.tsx
@@ -1,34 +1,19 @@
 
 // Import needed components
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { FileText, Settings } from 'lucide-react';
-import { ArticleSubmissionDialog } from '@/components/knowledge/ArticleSubmissionDialog';
-import { CategoryArticlesList } from '@/components/admin/CategoryArticlesList';
+import { CommunityRecommendationsList } from '@/components/knowledge/CommunityRecommendationsList';
+import { RecommendationSubmissionDialog } from '@/components/knowledge/RecommendationSubmissionDialog';
 import { KnowledgeNavigation } from '@/components/knowledge/KnowledgeNavigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProfile } from '@/hooks/profile';
-import { supabase } from '@/lib/supabase-client';
 
 const ModificationsPage = () => {
   const [submissionDialogOpen, setSubmissionDialogOpen] = useState(false);
   const { user } = useAuth();
   const { userData } = useProfile();
-  const [isAdmin, setIsAdmin] = useState(false);
-  
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (user) {
-        const { data } = await supabase.rpc("has_role", {
-          _role: "admin",
-        });
-        setIsAdmin(!!data);
-      }
-    };
-    
-    checkAdminStatus();
-  }, [user]);
   
   // Prepare user data for Layout with proper avatar logic
   const layoutUser = userData ? {
@@ -56,18 +41,15 @@ const ModificationsPage = () => {
           </div>
           <Button onClick={() => setSubmissionDialogOpen(true)}>
             <FileText className="mr-2 h-4 w-4" />
-            Submit Modification Article
+            Submit Modification Recommendation
           </Button>
         </div>
         
         <KnowledgeNavigation />
         
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Community Modification Articles</h2>
-          <CategoryArticlesList 
-            category="Modifications"
-            isAdmin={isAdmin} 
-          />
+          <h2 className="text-2xl font-semibold mb-4">Community Modification Recommendations</h2>
+          <CommunityRecommendationsList category="Modifications" />
         </div>
         
         <div className="mb-8">
@@ -77,16 +59,15 @@ const ModificationsPage = () => {
             <h3 className="text-xl font-medium mb-2">Coming Soon</h3>
             <p className="text-muted-foreground mb-4 max-w-lg mx-auto">
               We're showcasing a curated list of popular and effective Unimog modifications.
-              In the meantime, check out the community articles above.
+              In the meantime, check out the community recommendations above.
             </p>
           </div>
         </div>
         
-        {/* Article Submission Dialog */}
-        <ArticleSubmissionDialog
+        {/* Recommendation Submission Dialog */}
+        <RecommendationSubmissionDialog
           open={submissionDialogOpen}
           onOpenChange={setSubmissionDialogOpen}
-          category="Modifications"
         />
       </div>
     </Layout>

--- a/src/pages/knowledge/RepairPage.tsx
+++ b/src/pages/knowledge/RepairPage.tsx
@@ -1,33 +1,18 @@
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { FileText, Hammer } from 'lucide-react';
-import { ArticleSubmissionDialog } from '@/components/knowledge/ArticleSubmissionDialog';
-import { CategoryArticlesList } from '@/components/admin/CategoryArticlesList';
+import { CommunityRecommendationsList } from '@/components/knowledge/CommunityRecommendationsList';
+import { RecommendationSubmissionDialog } from '@/components/knowledge/RecommendationSubmissionDialog';
 import { KnowledgeNavigation } from '@/components/knowledge/KnowledgeNavigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProfile } from '@/hooks/profile';
-import { supabase } from '@/lib/supabase-client';
 
 const RepairPage = () => {
   const [submissionDialogOpen, setSubmissionDialogOpen] = useState(false);
   const { user } = useAuth();
   const { userData } = useProfile();
-  const [isAdmin, setIsAdmin] = useState(false);
-  
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (user) {
-        const { data } = await supabase.rpc("has_role", {
-          _role: "admin",
-        });
-        setIsAdmin(!!data);
-      }
-    };
-    
-    checkAdminStatus();
-  }, [user]);
   
   // Prepare user data for Layout with proper avatar logic
   const layoutUser = userData ? {
@@ -55,18 +40,15 @@ const RepairPage = () => {
           </div>
           <Button onClick={() => setSubmissionDialogOpen(true)}>
             <FileText className="mr-2 h-4 w-4" />
-            Submit Repair Article
+            Submit Repair Recommendation
           </Button>
         </div>
         
         <KnowledgeNavigation />
         
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Community Repair Articles</h2>
-          <CategoryArticlesList 
-            category="Repair"
-            isAdmin={isAdmin} 
-          />
+          <h2 className="text-2xl font-semibold mb-4">Community Repair Recommendations</h2>
+          <CommunityRecommendationsList category="Repair" />
         </div>
         
         <div className="mb-8">
@@ -76,16 +58,15 @@ const RepairPage = () => {
             <h3 className="text-xl font-medium mb-2">Coming Soon</h3>
             <p className="text-muted-foreground mb-4 max-w-lg mx-auto">
               We're compiling a database of common Unimog repair issues and solutions.
-              In the meantime, check out the community articles above.
+              In the meantime, check out the community recommendations above.
             </p>
           </div>
         </div>
         
-        {/* Article Submission Dialog */}
-        <ArticleSubmissionDialog
+        {/* Recommendation Submission Dialog */}
+        <RecommendationSubmissionDialog
           open={submissionDialogOpen}
           onOpenChange={setSubmissionDialogOpen}
-          category="Repair"
         />
       </div>
     </Layout>

--- a/src/pages/knowledge/TyresPage.tsx
+++ b/src/pages/knowledge/TyresPage.tsx
@@ -1,33 +1,18 @@
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
 import { FileText, Disc } from 'lucide-react';
-import { ArticleSubmissionDialog } from '@/components/knowledge/ArticleSubmissionDialog';
-import { CategoryArticlesList } from '@/components/admin/CategoryArticlesList';
+import { CommunityRecommendationsList } from '@/components/knowledge/CommunityRecommendationsList';
+import { RecommendationSubmissionDialog } from '@/components/knowledge/RecommendationSubmissionDialog';
 import { KnowledgeNavigation } from '@/components/knowledge/KnowledgeNavigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProfile } from '@/hooks/profile';
-import { supabase } from '@/lib/supabase-client';
 
 const TyresPage = () => {
   const [submissionDialogOpen, setSubmissionDialogOpen] = useState(false);
   const { user } = useAuth();
   const { userData } = useProfile();
-  const [isAdmin, setIsAdmin] = useState(false);
-  
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      if (user) {
-        const { data } = await supabase.rpc("has_role", {
-          _role: "admin",
-        });
-        setIsAdmin(!!data);
-      }
-    };
-    
-    checkAdminStatus();
-  }, [user]);
   
   // Prepare user data for Layout with proper avatar logic
   const layoutUser = userData ? {
@@ -56,7 +41,7 @@ const TyresPage = () => {
           <div>
             <Button onClick={() => setSubmissionDialogOpen(true)}>
               <FileText className="mr-2 h-4 w-4" />
-              Submit Tyre Article
+              Submit Tyre Recommendation
             </Button>
           </div>
         </div>
@@ -64,11 +49,8 @@ const TyresPage = () => {
         <KnowledgeNavigation />
         
         <div className="mb-8">
-          <h2 className="text-2xl font-semibold mb-4">Community Tyre Articles</h2>
-          <CategoryArticlesList 
-            category="Tyres" 
-            isAdmin={isAdmin}
-          />
+          <h2 className="text-2xl font-semibold mb-4">Community Tyre Recommendations</h2>
+          <CommunityRecommendationsList category="Tyres" />
         </div>
         
         <div className="mb-8">
@@ -78,16 +60,15 @@ const TyresPage = () => {
             <h3 className="text-xl font-medium mb-2">Coming Soon</h3>
             <p className="text-muted-foreground mb-4 max-w-lg mx-auto">
               We're compiling a comprehensive guide of tyre recommendations for various Unimog models and use cases.
-              In the meantime, check out the community articles above.
+              In the meantime, check out the community recommendations above.
             </p>
           </div>
         </div>
-        
-        {/* Article Submission Dialog */}
-        <ArticleSubmissionDialog
+
+        {/* Recommendation Submission Dialog */}
+        <RecommendationSubmissionDialog
           open={submissionDialogOpen}
           onOpenChange={setSubmissionDialogOpen}
-          category="Tyres"
         />
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- Replace article lists with `CommunityRecommendationsList` across Repair, Maintenance, Modifications, Tyres, and Adventures pages
- Update submission buttons and section headers to reference recommendations
- Add recommendation submission dialog and placeholders mentioning recommendations

## Testing
- `npm test` (no tests found)
- `npm run lint` (fails: A `require()` style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68aff7669904832381e19f06ee6375a2