### PR TITLE
feat: add community recommendations table

### DIFF
--- a/scripts/seed-community-recommendations.sql
+++ b/scripts/seed-community-recommendations.sql
@@ -1,0 +1,24 @@
+-- Seed sample data for community_recommendations
+INSERT INTO community_recommendations (
+    supplier_name,
+    category,
+    description,
+    location,
+    website_url,
+    author_id,
+    author_name,
+    author_avatar,
+    rating,
+    likes
+) VALUES (
+    'Mog Repair Specialists',
+    'Repair',
+    'Trusted workshop for all Unimog repairs.',
+    'Berlin, Germany',
+    'https://mogspecialists.example.com',
+    gen_random_uuid(),
+    'Admin User',
+    NULL,
+    5,
+    0
+);

--- a/supabase/migrations/20250214_add_community_recommendations.sql
+++ b/supabase/migrations/20250214_add_community_recommendations.sql
@@ -1,0 +1,43 @@
+-- Create enum type for recommendation categories
+CREATE TYPE recommendation_category AS ENUM ('Repair', 'Maintenance', 'Modifications', 'Tyres', 'Adventures');
+
+-- Create community_recommendations table
+CREATE TABLE community_recommendations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT timezone('utc', now()),
+    supplier_name TEXT NOT NULL,
+    category recommendation_category NOT NULL,
+    description TEXT,
+    location TEXT,
+    website_url TEXT,
+    author_id UUID REFERENCES profiles (id),
+    author_name TEXT,
+    author_avatar TEXT,
+    rating SMALLINT,
+    likes INTEGER DEFAULT 0
+);
+
+-- Enable Row Level Security
+ALTER TABLE community_recommendations ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies mirroring community_articles permissions
+
+-- Allow anyone to read recommendations
+CREATE POLICY "Anyone can read recommendations" ON community_recommendations
+    FOR SELECT
+    USING (true);
+
+-- Allow authenticated users to create recommendations
+CREATE POLICY "Authenticated users can create recommendations" ON community_recommendations
+    FOR INSERT
+    WITH CHECK (auth.uid() = author_id);
+
+-- Allow users to update their own recommendations
+CREATE POLICY "Users can update own recommendations" ON community_recommendations
+    FOR UPDATE
+    USING (auth.uid() = author_id);
+
+-- Allow users to delete their own recommendations
+CREATE POLICY "Users can delete own recommendations" ON community_recommendations
+    FOR DELETE
+    USING (auth.uid() = author_id);


### PR DESCRIPTION
## Summary
- add `community_recommendations` table and enum
- mirror article RLS policies for recommendations
- provide sample seed data for recommendations

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint` *(fails: 890 errors, 1359 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b00247416c8323a07a74a7e23c22a8