### PR TITLE
Increase Node heap for Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,8 @@
 [build.environment]
   NODE_VERSION = "22"
   NPM_VERSION = "10.9.2"
+  # Increase Node.js heap size to prevent out-of-memory errors during Netlify builds
+  NODE_OPTIONS = "--max-old-space-size=4096"
   # Secrets scanning configuration - These are public anon keys meant to be exposed in the frontend
   SECRETS_SCAN_OMIT_PATHS = "dist/**,docs/**"
   SECRETS_SCAN_OMIT_KEYS = "VITE_SUPABASE_ANON_KEY,VITE_MAPBOX_ACCESS_TOKEN"


### PR DESCRIPTION
## Summary
- configure the Netlify build environment to raise the Node.js heap limit and avoid OOM build failures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2124c7f0832383761c5f920f1a85