### PR TITLE
Generate PDF.js assets during install instead of committing binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,9 @@ Thumbs.db
 .temp/
 .build/
 
+# PDF.js assets are generated during install/build
+public/pdfjs/cmaps/
+public/pdfjs/standard_fonts/
+
 # Local Netlify folder
 .netlify

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "wis:safe": "node scripts/wis-safe-extractor.js",
     "wis:all": "npm run wis:extract && npm run wis:upload",
     "barry:test": "node scripts/test-barry-wis.js",
-    "barry:wis": "node scripts/test-barry-wis.js"
+    "barry:wis": "node scripts/test-barry-wis.js",
+    "setup:pdf-assets": "node scripts/setup-pdf-assets.js",
+    "postinstall": "node scripts/setup-pdf-assets.js"
   },
   "overrides": {
     "dotenv": "^16.4.5"

--- a/public/pdfjs/README.md
+++ b/public/pdfjs/README.md
@@ -1,0 +1,14 @@
+# PDF.js Static Assets
+
+This directory is populated at install/build time with the assets that PDF.js needs for reliable text rendering within the Unimog Community Hub PDF viewer.
+
+- `standard_fonts/`: Standard font program files copied from `pdfjs-dist@3.11.174`. These files allow the PDF canvas renderer to embed fallback fonts without relying on external CDNs that are blocked by the current Content Security Policy.
+- `cmaps/`: Character map data copied from `pdfjs-dist@3.11.174`. The viewer uses these files to correctly decode embedded fonts and render glyphs.
+
+The contents of these folders are not committed to the repository (to avoid storing large/binary assets). Instead they are copied from `node_modules/pdfjs-dist` by `scripts/setup-pdf-assets.js`, which is executed automatically via the `postinstall` npm script and during the Netlify build pipeline. If you ever need to refresh the assets manually you can run:
+
+```
+npm run setup:pdf-assets
+```
+
+Hosting these assets locally ensures that Chromium-based browsers can render PDF text even when network access to external CDNs is restricted.

--- a/scripts/build-netlify.js
+++ b/scripts/build-netlify.js
@@ -43,6 +43,15 @@ try {
   process.exit(1);
 }
 
+// Ensure PDF.js assets are available before the build runs
+console.log('📚 Preparing PDF.js assets...');
+try {
+  execSync('node scripts/setup-pdf-assets.js', { stdio: 'inherit' });
+} catch (error) {
+  console.error('❌ Failed to prepare PDF.js assets');
+  process.exit(1);
+}
+
 // Run the actual build
 console.log('🏗️ Building application...');
 try {

--- a/scripts/setup-pdf-assets.js
+++ b/scripts/setup-pdf-assets.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const publicPdfDir = path.join(projectRoot, 'public', 'pdfjs');
+
+const sources = [
+  {
+    name: 'cMaps',
+    from: path.join(projectRoot, 'node_modules', 'pdfjs-dist', 'cmaps'),
+    to: path.join(publicPdfDir, 'cmaps')
+  },
+  {
+    name: 'standard fonts',
+    from: path.join(projectRoot, 'node_modules', 'pdfjs-dist', 'standard_fonts'),
+    to: path.join(publicPdfDir, 'standard_fonts')
+  }
+];
+
+async function pathExists(targetPath) {
+  try {
+    await fs.promises.access(targetPath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeDirectoryIfExists(targetPath) {
+  if (await pathExists(targetPath)) {
+    await fs.promises.rm(targetPath, { recursive: true, force: true });
+  }
+}
+
+async function copyDirectory(source, destination) {
+  await fs.promises.mkdir(destination, { recursive: true });
+  const entries = await fs.promises.readdir(source, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(source, entry.name);
+    const destPath = path.join(destination, entry.name);
+
+    if (entry.isDirectory()) {
+      await copyDirectory(srcPath, destPath);
+    } else if (entry.isFile()) {
+      await fs.promises.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+async function ensurePdfAssets() {
+  let didCopy = false;
+
+  await fs.promises.mkdir(publicPdfDir, { recursive: true });
+
+  for (const { name, from, to } of sources) {
+    const hasSource = await pathExists(from);
+    if (!hasSource) {
+      console.warn(`⚠️  PDF.js ${name} source not found at ${from}. Did you run "npm install"?`);
+      continue;
+    }
+
+    await removeDirectoryIfExists(to);
+    await copyDirectory(from, to);
+    console.log(`✅ Copied PDF.js ${name} to ${path.relative(projectRoot, to)}`);
+    didCopy = true;
+  }
+
+  if (!didCopy) {
+    console.warn('⚠️  No PDF.js assets were copied. PDF text rendering may fail.');
+  }
+}
+
+ensurePdfAssets().catch((error) => {
+  console.error('❌ Failed to prepare PDF.js assets:', error);
+  process.exitCode = 1;
+});

--- a/src/components/knowledge/pdf-viewer/usePdfLoader.ts
+++ b/src/components/knowledge/pdf-viewer/usePdfLoader.ts
@@ -1,11 +1,12 @@
 
 import { useEffect } from 'react';
 import * as pdfjsLib from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist/types/src/display/api';
 import { setupPdfWorker, setupPdfWorkerSync } from '@/utils/pdfWorkerSetup';
 
 interface UsePdfLoaderProps {
   url: string;
-  setPdfDoc: (doc: any) => void;
+  setPdfDoc: (doc: PDFDocumentProxy | null) => void;
   setNumPages: (pages: number) => void;
   setCurrentPage: (page: number) => void;
   setIsLoading: (loading: boolean) => void;
@@ -21,15 +22,45 @@ export const usePdfLoader = ({
   setError
 }: UsePdfLoaderProps) => {
   useEffect(() => {
-    let retryCount = 0;
     const maxRetries = 2;
     
+    const baseUrl = import.meta.env.BASE_URL ?? '/';
+    const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    const localPdfAssetsBase = `${normalizedBaseUrl}pdfjs/`;
+
+    const cMapSources = [
+      `${localPdfAssetsBase}cmaps/`,
+      `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/cmaps/`,
+      `https://unpkg.com/pdfjs-dist@${pdfjsLib.version}/cmaps/`,
+      `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/cmaps/`
+    ];
+
+    const standardFontSources = [
+      `${localPdfAssetsBase}standard_fonts/`,
+      `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/standard_fonts/`,
+      `https://unpkg.com/pdfjs-dist@${pdfjsLib.version}/standard_fonts/`
+    ];
+
+    const resolveCMapUrl = (attempt: number) => {
+      if (attempt <= cMapSources.length) {
+        return cMapSources[attempt - 1];
+      }
+      return cMapSources[cMapSources.length - 1];
+    };
+
+    const resolveStandardFontUrl = (attempt: number) => {
+      if (attempt <= standardFontSources.length) {
+        return standardFontSources[attempt - 1];
+      }
+      return undefined;
+    };
+
     const loadPdf = async (attempt = 1) => {
       try {
         setIsLoading(true);
         setError(null);
 
-        console.log(`📄 Loading PDF (attempt ${attempt}/${maxRetries + 1}):`, url);
+        console.info(`📄 Loading PDF (attempt ${attempt}/${maxRetries + 1}):`, url);
         
         // Check if URL is valid
         if (!url || url === 'null' || url === 'undefined') {
@@ -38,7 +69,7 @@ export const usePdfLoader = ({
 
         // Attempt to reconfigure worker on retry attempts
         if (attempt > 1) {
-          console.log(`🔧 Reconfiguring PDF worker for attempt ${attempt}`);
+          console.info(`🔧 Reconfiguring PDF worker for attempt ${attempt}`);
           try {
             await setupPdfWorker();
           } catch (workerError) {
@@ -48,6 +79,9 @@ export const usePdfLoader = ({
         }
 
         // Load PDF with robust options and multiple fallback strategies
+        const standardFontDataUrl = resolveStandardFontUrl(attempt);
+        const cMapUrl = resolveCMapUrl(attempt);
+
         const loadingOptions = {
           url,
           withCredentials: false,
@@ -55,28 +89,20 @@ export const usePdfLoader = ({
           disableStream: attempt > 2, // Disable streaming on final attempt
           isEvalSupported: false, // Disable eval for security
           disableAutoFetch: attempt > 1, // Disable auto fetching on retries
-          disableFontFace: attempt > 2, // Disable font loading on final attempt
-          useSystemFonts: attempt > 1, // Use system fonts on retries
-          // Use multiple CDN fallbacks for resources
-          cMapUrl: attempt === 1 
-            ? `https://unpkg.com/pdfjs-dist@${pdfjsLib.version}/cmaps/`
-            : attempt === 2 
-            ? `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/cmaps/`
-            : `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/cmaps/`,
+          disableFontFace: !standardFontDataUrl, // Disable font loading when no source available
+          useSystemFonts: !standardFontDataUrl, // Rely on system fonts only when we run out of sources
+          cMapUrl,
           cMapPacked: true,
-          standardFontDataUrl: attempt === 1 
-            ? `https://unpkg.com/pdfjs-dist@${pdfjsLib.version}/standard_fonts/`
-            : attempt === 2 
-            ? `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/standard_fonts/`
-            : undefined, // Skip font data on final attempt
+          standardFontDataUrl,
           maxImageSize: attempt > 1 ? 1024 * 1024 : -1, // Limit image size on retries
           verbosity: attempt > 2 ? 0 : 1 // Reduce logging on final attempt
         };
 
-        console.log(`🔧 PDF loading options for attempt ${attempt}:`, {
+        console.info(`🔧 PDF loading options for attempt ${attempt}:`, {
           disableRange: loadingOptions.disableRange,
           disableStream: loadingOptions.disableStream,
-          cMapUrl: loadingOptions.cMapUrl
+          cMapUrl: loadingOptions.cMapUrl,
+          standardFontDataUrl: loadingOptions.standardFontDataUrl
         });
         
         const loadingTask = pdfjsLib.getDocument(loadingOptions);
@@ -91,7 +117,7 @@ export const usePdfLoader = ({
         
         const pdf = await pdfPromise;
         
-        console.log('✅ PDF loaded successfully:', {
+        console.info('✅ PDF loaded successfully:', {
           pages: pdf.numPages,
           version: pdfjsLib.version,
           attempt: attempt
@@ -101,31 +127,33 @@ export const usePdfLoader = ({
         setNumPages(pdf.numPages);
         setCurrentPage(1);
         
-      } catch (error: any) {
+      } catch (error: unknown) {
         console.error(`❌ PDF loading error (attempt ${attempt}):`, error);
-        
+
+        const errorMessageText = error instanceof Error ? error.message : String(error);
+
         // Detect specific error types and decide on retry strategy
-        const isWorkerError = error.message?.includes('WorkerMessageHandler') || 
-                             error.message?.includes('fake worker') ||
-                             error.message?.includes('Cannot load script') ||
-                             error.message?.includes('worker');
-                             
-        const isNetworkError = error.message?.includes('CORS') ||
-                              error.message?.includes('timeout') ||
-                              error.message?.includes('fetch');
-                              
-        const isInvalidUrl = error.message?.includes('Invalid PDF URL');
+        const isWorkerError = errorMessageText.includes('WorkerMessageHandler') ||
+                             errorMessageText.includes('fake worker') ||
+                             errorMessageText.includes('Cannot load script') ||
+                             errorMessageText.includes('worker');
+
+        const isNetworkError = errorMessageText.includes('CORS') ||
+                              errorMessageText.includes('timeout') ||
+                              errorMessageText.includes('fetch');
+
+        const isInvalidUrl = errorMessageText.includes('Invalid PDF URL');
         
         if (isWorkerError) {
-          console.log('🔧 Worker-related error detected, will retry with different worker configuration');
+          console.info('🔧 Worker-related error detected, will retry with different worker configuration');
         } else if (isNetworkError) {
-          console.log('🌐 Network-related error detected, will retry with different loading options');
+          console.info('🌐 Network-related error detected, will retry with different loading options');
         }
         
         // If we have retries left, try again with different strategies
         if (attempt <= maxRetries && !isInvalidUrl) {
           const retryDelay = attempt === 1 ? 1000 : 2000; // Longer delay for subsequent retries
-          console.log(`🔄 Retrying PDF load in ${retryDelay/1000} second(s)... (${attempt}/${maxRetries})`);
+          console.info(`🔄 Retrying PDF load in ${retryDelay/1000} second(s)... (${attempt}/${maxRetries})`);
           setTimeout(() => loadPdf(attempt + 1), retryDelay);
           return;
         }
@@ -135,13 +163,13 @@ export const usePdfLoader = ({
         
         if (isWorkerError) {
           errorMessage = 'PDF viewer initialization failed. Falling back to simple viewer. You can also try refreshing the page.';
-        } else if (error.message?.includes('timeout')) {
+        } else if (errorMessageText.includes('timeout')) {
           errorMessage = 'PDF loading timed out. The document may be too large or your connection may be slow. Falling back to simple viewer.';
-        } else if (error.message?.includes('CORS')) {
+        } else if (errorMessageText.includes('CORS')) {
           errorMessage = 'PDF loading blocked by security policy. Falling back to simple viewer.';
-        } else if (error.message?.includes('Invalid PDF')) {
+        } else if (errorMessageText.includes('Invalid PDF')) {
           errorMessage = 'The document appears to be corrupted or is not a valid PDF.';
-        } else if (error.message?.includes('404') || error.message?.includes('Not Found')) {
+        } else if (errorMessageText.includes('404') || errorMessageText.includes('Not Found')) {
           errorMessage = 'PDF document not found. It may have been moved or deleted.';
         } else if (isInvalidUrl) {
           errorMessage = 'Invalid PDF URL. Please try refreshing the page.';
@@ -150,7 +178,7 @@ export const usePdfLoader = ({
         }
         
         console.error(`💥 Final PDF loading failure:`, errorMessage);
-        console.log('🔄 The page will automatically fall back to the simple PDF viewer');
+        console.info('🔄 The page will automatically fall back to the simple PDF viewer');
         setError(errorMessage);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- remove the committed PDF.js cMap and standard font binaries and ignore the directories so the repository no longer tracks them
- add a setup script that copies the assets from pdfjs-dist during postinstall and before Netlify builds so the viewer still finds local files
- document the workflow in public/pdfjs/README.md and adjust supporting config to reflect the generated assets

## Testing
- npm run lint *(fails: eslint-plugin-react-hooks "context.getSource is not a function" in backup/trip-planner-poi-fixes-20250917-231611/FullScreenTripMapWithWaypoints 2.tsx)*
- npx eslint scripts/setup-pdf-assets.js scripts/build-netlify.js

------
https://chatgpt.com/codex/tasks/task_e_68cf3704c1f883238435927a45e53123