### PR TITLE
Fix PDF viewer text overlay visibility

### DIFF
--- a/src/components/knowledge/PdfTextLayer.tsx
+++ b/src/components/knowledge/PdfTextLayer.tsx
@@ -66,12 +66,13 @@ export function PdfTextLayer({ pdfDoc, currentPage, scale, viewport }: PdfTextLa
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 pointer-events-none"
+      className="absolute inset-0"
       style={{
         width: viewport.width,
         height: viewport.height,
         zIndex: 2, // Above canvas but below UI controls
       }}
+      aria-hidden="true"
     >
       {textItems.map((item, index) => {
         // Extract position from transform matrix [a, b, c, d, e, f]
@@ -96,14 +97,11 @@ export function PdfTextLayer({ pdfDoc, currentPage, scale, viewport }: PdfTextLa
               top: adjustedY,
               fontSize: `${fontSize}px`,
               fontFamily: 'Arial, sans-serif', // Fallback font
-              color: 'black',
-              whiteSpace: 'nowrap',
+              color: 'transparent',
+              whiteSpace: 'pre',
+              lineHeight: 1,
               userSelect: 'text',
               pointerEvents: 'auto', // Allow text selection
-              // Add slight transparency to see underlying graphics
-              opacity: 0.9,
-              // Prevent text from being too small to read
-              minHeight: '8px',
             }}
           >
             {item.str}


### PR DESCRIPTION
## Summary
- hide the manual PDF text layer overlay by rendering its text as transparent while keeping the spans selectable
- remove pointer-events suppression from the text layer container and mark it aria-hidden for accessibility

## Testing
- npm run lint *(fails: ESLint TypeError in legacy backup file outside change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3bab941883239c159d1426a42eb4