### PR TITLE
Fix ensureSystemDetails initialization order

### DIFF
--- a/src/components/wis/WISProfessionalInterface.tsx
+++ b/src/components/wis/WISProfessionalInterface.tsx
@@ -256,16 +256,6 @@ const WISProfessionalInterface: React.FC<WISProfessionalInterfaceProps> = ({
     setLoadingCount((count) => (count > 0 ? count - 1 : 0));
   }, []);
 
-  useEffect(() => {
-    if (expandedSystems.length === 0) {
-      return;
-    }
-
-    expandedSystems.forEach((systemId) => {
-      ensureSystemDetails(systemId);
-    });
-  }, [expandedSystems, ensureSystemDetails]);
-
   const getDifficultyLabel = useCallback((level?: number | null) => {
     if (!level || level <= 1) {
       return 'Easy';
@@ -406,6 +396,16 @@ const WISProfessionalInterface: React.FC<WISProfessionalInterfaceProps> = ({
       systems,
     ]
   );
+
+  useEffect(() => {
+    if (expandedSystems.length === 0) {
+      return;
+    }
+
+    expandedSystems.forEach((systemId) => {
+      ensureSystemDetails(systemId);
+    });
+  }, [expandedSystems, ensureSystemDetails]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
- move the effect that loads system details so the ensureSystemDetails callback is defined before it is referenced
- prevent the WIS Professional Interface from throwing a ReferenceError when expanding systems

## Testing
- pnpm lint *(fails: eslint-plugin-react-hooks throws `context.getSource is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4fbc4cd0832385f7e18125baac23