### PR TITLE
Add PRDs for Barry Tools v2 (Phase 1–3): architecture, rollout, and decommission plan

### DIFF
--- a/docs/BARRY_TOOLS_PHASE_1_PRD.md
+++ b/docs/BARRY_TOOLS_PHASE_1_PRD.md
@@ -1,0 +1,125 @@
+# PRD: Barry Tools v2 — Phase 1 (Foundation & Pilot)
+
+## Document Control
+- **Owner:** AI Platform / Barry Team
+- **Status:** Draft
+- **Target Environment:** Staging first, limited production pilot
+- **Last Updated:** 2026-04-26
+
+---
+
+## 1) Problem Statement
+Barry currently performs best on workshop-manual-citation workflows, but non-technical questions can be mishandled because manual-oriented prompting and gatherer orchestration dominate routing behavior.
+
+Phase 1 establishes a new tool-native architecture (`barry-tools`) that allows the model to decide when tools are needed and avoids forcing manual context into every query.
+
+## 2) Goals
+1. Launch a new Supabase edge function, `barry-tools`, with Anthropic native tool-use loop.
+2. Implement and production-harden the **core tool set** needed for immediate quality gains.
+3. Preserve response contract compatibility with current frontend consumers.
+4. Pilot on one controlled frontend surface with observable metrics.
+
+## 3) Non-Goals
+- Full migration of all Barry surfaces.
+- Immediate deprecation of legacy functions (`chat-with-barry-agentic`, `barry-openclaw`).
+- Introducing new UI paradigms or response rendering models.
+
+## 4) Scope
+
+### In Scope
+- New edge function scaffolding and orchestration loop.
+- Core tools:
+  - `search_manual`
+  - `lookup_knowledge_base`
+  - `get_weather`
+  - `web_search`
+  - `convert_units`
+  - `translate_text`
+- Shared tool registry and types under `openclaw-core/tools/*`.
+- Guardrails parity with existing security/safety flow.
+- Pilot routing flag for one frontend entrypoint.
+
+### Out of Scope
+- Route planning, nearby services, and marketplace/event search tools.
+- RPS/EPC deep parts workflows beyond compatibility stubs.
+
+## 5) Users & Primary Jobs-to-be-Done
+1. **Unimog owners/mechanics:** Get accurate manual-backed technical guidance.
+2. **Travel users:** Get weather/general trip context without fabricated manual citations.
+3. **Support/admin teams:** Observe model/tool behavior and debug incidents quickly.
+
+## 6) Functional Requirements
+
+### FR-1: Tool-Use Runtime Loop
+- System prompt + conversation history + tool definitions sent to Anthropic.
+- Model may respond with `tool_use` or direct answer.
+- Runtime executes requested tools, appends results, and continues.
+- Hard stop at configurable max iterations (default: 5).
+
+### FR-2: Response Contract Compatibility
+Function output must preserve existing contract:
+- `content`
+- `manualReferences`
+- `knowledgeMode`
+- `searchResultCount`
+- `skill_chain`
+
+### FR-3: Citation Behavior
+- Manual citations only when `search_manual` is called and results exist.
+- If no manual results: explicit no-result handling; do not fabricate references.
+
+### FR-4: Guardrails Parity
+Carry over:
+- Rate limiting
+- Prompt injection detection
+- Input sanitization
+- Dangerous-topic policy + safety disclaimers
+
+### FR-5: Tool Error Handling
+- Every tool returns structured success/error envelopes.
+- Non-fatal tool failures do not crash final response unless no answer is possible.
+
+## 7) Non-Functional Requirements
+- **Latency:** p50 <= current baseline for simple queries; p95 not more than +20% during pilot.
+- **Reliability:** >= 99% successful edge responses during pilot window.
+- **Observability:** request-level and tool-level logs with latency and outcome.
+- **Security:** no regression in blocked-topic or prompt-injection defenses.
+
+## 8) Success Metrics
+1. **Manual-citation precision:** no decrease vs baseline.
+2. **Off-domain hallucination reduction:** >= 50% reduction in sampled eval set.
+3. **Tool invocation efficiency:** average tool calls/query <= 2.0 for pilot surface.
+4. **User quality signal:** thumbs-down rate not worse than baseline.
+
+## 9) Milestones
+1. Implement function + core tools.
+2. Add eval harness and smoke tests.
+3. Deploy to staging.
+4. Enable pilot on one frontend surface.
+5. Run 7-day monitored pilot.
+
+## 10) Dependencies
+- Anthropic API credentials and model configuration.
+- Brave Search API key.
+- Existing manual and KB data stores.
+- Existing guardrail utilities.
+
+## 11) Risks & Mitigations
+- **Risk:** Tool-call loops increase cost/latency.
+  - **Mitigation:** hard iteration cap, per-tool timeout, call budget.
+- **Risk:** Web tool data quality variability.
+  - **Mitigation:** source labeling + fallback messaging.
+- **Risk:** Schema drift from existing frontend contract.
+  - **Mitigation:** contract tests for response shape.
+
+## 12) Testing & Validation
+- Unit tests for tool input/output schema validation.
+- Integration tests for loop behavior (0-tool, 1-tool, multi-tool, tool-error paths).
+- Regression tests for safety guardrails and response shape.
+- Pilot shadow evaluation against curated query set.
+
+## 13) Exit Criteria (Phase 1 Done)
+- Core tool set live on pilot surface.
+- Success metrics met for at least 7 consecutive days.
+- No P0/P1 safety regressions.
+

--- a/docs/BARRY_TOOLS_PHASE_2_PRD.md
+++ b/docs/BARRY_TOOLS_PHASE_2_PRD.md
@@ -1,0 +1,111 @@
+# PRD: Barry Tools v2 — Phase 2 (Capability Expansion & Controlled Rollout)
+
+## Document Control
+- **Owner:** AI Platform / Barry Team
+- **Status:** Draft
+- **Target Environment:** Staging + incremental production rollout
+- **Last Updated:** 2026-04-26
+
+---
+
+## 1) Problem Statement
+After Phase 1 proves the tool-native architecture, Barry still lacks broad operational capabilities required for travel and ownership workflows (parts ecosystems, route support, local services, marketplace/events).
+
+Phase 2 expands tool coverage while maintaining strict reliability and guardrails.
+
+## 2) Goals
+1. Add the extended tool suite for parts, location, and community workflows.
+2. Introduce progressive rollout controls (traffic percentage / surface-level flags).
+3. Harden observability, cost controls, and fallback behavior under scale.
+
+## 3) Non-Goals
+- Full shutdown of legacy paths.
+- Major frontend redesign.
+- Autonomous multi-step transaction execution (booking/purchasing).
+
+## 4) Scope
+
+### In Scope
+- Add tools:
+  - `search_rps`
+  - `search_epc`
+  - `lookup_fuel_prices`
+  - `find_nearby_services`
+  - `lookup_user_vehicle`
+  - `search_marketplace`
+  - `get_events`
+  - `search_community_content`
+  - `calculate_route`
+- Add traffic shaping control (e.g., `BARRY_TOOLS_TRAFFIC_PERCENT`).
+- Add per-tool policy constraints (budget/timeouts/allowlists).
+- Expand evaluation corpus and monitoring dashboards.
+
+### Out of Scope
+- Legacy function deletion.
+- Tool-generated write operations to user/account data.
+
+## 5) Functional Requirements
+
+### FR-1: Expanded Tool Registry
+- All Phase 2 tools exposed via central registry with clear descriptions and schemas.
+- Tools return normalized response envelopes.
+
+### FR-2: Location-Aware Behaviors
+- Tools using location must gracefully degrade when location is missing.
+- Explicit user-facing message when location precision is insufficient.
+
+### FR-3: User Vehicle Context
+- `lookup_user_vehicle` integrated as optional context enhancer, not hard requirement.
+- If unavailable, Barry still answers with neutral assumptions.
+
+### FR-4: Cost & Latency Controls
+- Per-tool timeout thresholds.
+- Per-request tool-call budget.
+- Skip low-value tool calls when confidence is high from existing grounded sources.
+
+### FR-5: Rollout Controls
+- Function-level percentage ramp control.
+- Surface-level override for explicit pilot cohorts.
+
+## 6) Non-Functional Requirements
+- **Scalability:** sustain expected concurrent traffic with no degradation > agreed SLO.
+- **Performance:** p95 latency for multi-tool paths bounded by timeout strategy.
+- **Auditability:** request trace includes ordered tool call chain and outcome.
+
+## 7) Success Metrics
+1. Improved answer coverage for non-manual use cases (weather/travel/local services).
+2. <= 2% tool execution failure rate (non-user-caused).
+3. Stable or improved user satisfaction on migrated surfaces.
+4. No regression in citation correctness for technical/manual answers.
+
+## 8) Milestones
+1. Implement expanded tools + registry updates.
+2. Add integration tests and synthetic replay suite.
+3. Staging soak test.
+4. Ramp production traffic: 10% -> 25% -> 50% (or equivalent surface expansion).
+5. Mid-phase review and hardening pass.
+
+## 9) Dependencies
+- External APIs (Brave, Mapbox, weather) with keys/quotas.
+- Supabase schemas for marketplace/events/profile queries.
+- Logging/metrics backend for tool-level telemetry.
+
+## 10) Risks & Mitigations
+- **Risk:** API quota/rate-limit exhaustion.
+  - **Mitigation:** caching, backoff, fail-soft responses.
+- **Risk:** Location inaccuracies cause poor recommendations.
+  - **Mitigation:** confidence labels + request clarification.
+- **Risk:** Tool sprawl causes maintenance burden.
+  - **Mitigation:** strict interface contracts and registry-level linting/tests.
+
+## 11) Testing & Validation
+- Contract tests for all new tool schemas.
+- Integration tests for representative multi-tool orchestration chains.
+- Resilience tests: timeouts, partial failures, malformed upstream payloads.
+- Shadow-mode comparisons against legacy responses where applicable.
+
+## 12) Exit Criteria (Phase 2 Done)
+- All Phase 2 tools production-capable.
+- Controlled rollout reaches >= 50% target traffic/surfaces without SLO breach.
+- On-call runbook updated with tool-specific failure playbooks.
+

--- a/docs/BARRY_TOOLS_PHASE_3_PRD.md
+++ b/docs/BARRY_TOOLS_PHASE_3_PRD.md
@@ -1,0 +1,95 @@
+# PRD: Barry Tools v2 — Phase 3 (Full Migration, Optimization, and Legacy Decommission)
+
+## Document Control
+- **Owner:** AI Platform / Barry Team
+- **Status:** Draft
+- **Target Environment:** Full production
+- **Last Updated:** 2026-04-26
+
+---
+
+## 1) Problem Statement
+With core and expanded tools delivered, the platform remains operationally complex while legacy Barry functions continue in parallel. This creates duplicated maintenance, split telemetry, and inconsistent behavior.
+
+Phase 3 completes migration, optimizes quality/cost, and decommissions superseded paths.
+
+## 2) Goals
+1. Migrate all Barry chat surfaces to `barry-tools`.
+2. Retire legacy Barry pathways safely.
+3. Establish long-term governance for tools, evals, and model changes.
+
+## 3) Non-Goals
+- Launching unrelated product features outside Barry assistant scope.
+- Real-time autonomous actuation (purchases/bookings/vehicle control).
+
+## 4) Scope
+
+### In Scope
+- Final migration of all frontend entrypoints to `barry-tools`.
+- Legacy deprecation plan:
+  - `chat-with-barry-agentic`
+  - `barry-openclaw` (as active inference path)
+- Cost/performance optimization pass.
+- Long-term quality governance (automated eval gates, regression alarms).
+
+### Out of Scope
+- Full rewrite of historical analytics systems.
+
+## 5) Functional Requirements
+
+### FR-1: 100% Routing Completion
+- All supported Barry surfaces route to `barry-tools` by default.
+- Emergency rollback switch preserved for one release cycle.
+
+### FR-2: Legacy Decommission
+- Legacy functions marked read-only/disabled after migration soak period.
+- Operational docs updated to reference new architecture only.
+
+### FR-3: Quality Governance
+- Add release gate requiring eval pass before model/tool prompt changes.
+- Introduce periodic benchmark suite covering technical + non-technical tasks.
+
+### FR-4: Cost Governance
+- Publish monthly token/tool spend report.
+- Enforce configurable caps and alerting thresholds.
+
+## 6) Non-Functional Requirements
+- **Reliability:** meet or exceed existing production SLOs across all surfaces.
+- **Consistency:** no surface-specific behavior divergence without explicit policy.
+- **Maintainability:** clear ownership and versioning policy for each tool.
+
+## 7) Success Metrics
+1. 100% production traffic on `barry-tools` for 30 consecutive days.
+2. No critical incident attributable to migration after rollback window closes.
+3. Lower blended cost per resolved query vs pre-migration baseline.
+4. Improved blended quality score across technical + general benchmarks.
+
+## 8) Milestones
+1. Complete final surface migrations.
+2. Run 2-week full-traffic soak period.
+3. Finalize deprecation checklist and archive legacy runbooks.
+4. Remove legacy routing references from codepaths and docs.
+
+## 9) Dependencies
+- Successful completion of Phase 1 and Phase 2 exit criteria.
+- Stakeholder sign-off from support, product, and platform owners.
+
+## 10) Risks & Mitigations
+- **Risk:** Hidden dependency on legacy endpoints.
+  - **Mitigation:** endpoint usage telemetry + staged disablement.
+- **Risk:** Regression from model/prompt iteration.
+  - **Mitigation:** mandatory automated eval gate.
+- **Risk:** Operator confusion during cutover.
+  - **Mitigation:** one-source-of-truth runbook and escalation policy.
+
+## 11) Testing & Validation
+- End-to-end smoke tests for every migrated surface.
+- Production canary checks with rollback drill.
+- Regression suite executed before and after legacy disablement.
+- Disaster recovery simulation for tool/API outages.
+
+## 12) Exit Criteria (Phase 3 Done)
+- Legacy paths decommissioned.
+- Governance controls active and documented.
+- `barry-tools` is sole production inference path with stable SLO/SLA compliance.
+


### PR DESCRIPTION
### Motivation
- Define a phased plan to move Barry to a tool-native architecture (`barry-tools`) so the model can invoke tools directly and avoid over-relying on manual-oriented prompting. 
- Provide concrete goals, scope, required core and expanded tools, guardrails, and success metrics for an incremental migration and pilot. 
- Capture operational and decommissioning requirements to minimize risk while migrating surfaces and retiring legacy paths.

### Description
- Add three new product requirement documents: `docs/BARRY_TOOLS_PHASE_1_PRD.md`, `docs/BARRY_TOOLS_PHASE_2_PRD.md`, and `docs/BARRY_TOOLS_PHASE_3_PRD.md` containing Phase 1 (foundation & pilot), Phase 2 (capability expansion & controlled rollout), and Phase 3 (full migration & legacy decommission) plans. 
- Phase 1 specifies the new edge function `barry-tools`, the Anthropic tool-use runtime loop, the core tool set (`search_manual`, `lookup_knowledge_base`, `get_weather`, `web_search`, `convert_units`, `translate_text`), response contract compatibility, and guardrails. 
- Phase 2 expands the tool registry with additional tools (parts, location, marketplace, routing), adds traffic shaping and per-tool policy controls, and tightens cost/latency constraints. 
- Phase 3 defines final migration requirements, legacy function deprecation (`chat-with-barry-agentic`, `barry-openclaw`), governance, cost/quality optimization, and exit criteria.

### Testing
- No automated tests were executed for this documentation-only change; the PRDs themselves list planned unit, integration, contract, and resilience tests to be implemented in subsequent engineering work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed896cccfc83239751a0cb54a2f48d)