### PR TITLE
Normalize barry-tools responses, deduplicate manual references, and add unit tests

### DIFF
--- a/src/__tests__/unit/services/barryToolsService.test.ts
+++ b/src/__tests__/unit/services/barryToolsService.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { normaliseBarryToolsResponse } from '@/services/openclaw/barryToolsService';
+
+describe('normaliseBarryToolsResponse', () => {
+  it('maps barry-tools response shape into BarryOpenClawResponse contract', () => {
+    const result = normaliseBarryToolsResponse({
+      content: 'Test answer',
+      manualReferences: [
+        { page_number: 42, storage_url: 'https://example.com/manual.pdf#page=42', title: 'Axle Service' },
+      ],
+      knowledgeMode: 'search_manual',
+      searchResultCount: 1,
+      skill_chain: ['search_manual'],
+      execution_time_ms: 1234,
+    });
+
+    expect(result.content).toBe('Test answer');
+    expect(result.knowledgeMode).toBe('search_manual');
+    expect(result.searchResultCount).toBe(1);
+    expect(result.skill_chain).toEqual(['search_manual']);
+    expect(result.execution_time_ms).toBe(1234);
+    expect(result.manualReferences).toEqual([
+      {
+        type: 'manual',
+        title: 'Axle Service',
+        page_number: 42,
+        original_page: 42,
+        pdf_page: 42,
+        storage_url: 'https://example.com/manual.pdf#page=42',
+        manual_type: 'manual',
+      },
+    ]);
+  });
+
+  it('deduplicates manual references and applies safe defaults', () => {
+    const result = normaliseBarryToolsResponse({
+      manualReferences: [
+        { page_number: 10, storage_url: 'https://example.com/manual.pdf#page=10' },
+        { page_number: 10, storage_url: 'https://example.com/manual.pdf#page=10' },
+      ],
+    });
+
+    expect(result.content).toBe('');
+    expect(result.knowledgeMode).toBe('tool_use');
+    expect(result.searchResultCount).toBe(0);
+    expect(result.skill_chain).toEqual([]);
+    expect(result.manualReferences).toHaveLength(1);
+    expect(result.manualReferences[0].title).toBe('U435 Workshop Manual');
+  });
+});

--- a/src/services/openclaw/barryToolsService.ts
+++ b/src/services/openclaw/barryToolsService.ts
@@ -7,6 +7,58 @@ export interface BarryToolsRequest {
   conversationId?: string;
 }
 
+type BarryToolsManualReference = {
+  page_number: number;
+  storage_url: string;
+  title?: string;
+};
+
+type BarryToolsResponse = {
+  content?: string;
+  manualReferences?: BarryToolsManualReference[];
+  knowledgeMode?: string;
+  searchResultCount?: number;
+  skill_chain?: string[];
+  execution_time_ms?: number;
+};
+
+function normaliseManualReferences(
+  rawRefs: BarryToolsManualReference[] | undefined
+): ManualReference[] {
+  const refs = rawRefs ?? [];
+  const seen = new Set<string>();
+  const normalised: ManualReference[] = [];
+
+  for (const ref of refs) {
+    const key = `${ref.page_number}|${ref.storage_url}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    normalised.push({
+      type: 'manual',
+      title: ref.title ?? 'U435 Workshop Manual',
+      page_number: ref.page_number,
+      original_page: ref.page_number,
+      pdf_page: ref.page_number,
+      storage_url: ref.storage_url,
+      manual_type: 'manual',
+    });
+  }
+
+  return normalised;
+}
+
+export function normaliseBarryToolsResponse(data: BarryToolsResponse): BarryOpenClawResponse {
+  return {
+    content: data.content ?? '',
+    manualReferences: normaliseManualReferences(data.manualReferences),
+    knowledgeMode: data.knowledgeMode ?? 'tool_use',
+    searchResultCount: data.searchResultCount ?? 0,
+    skill_chain: data.skill_chain ?? [],
+    execution_time_ms: data.execution_time_ms,
+  };
+}
+
 /**
  * Calls the barry-tools edge function and normalises the response to the
  * same shape as BarryOpenClawResponse so existing UI works unchanged.
@@ -21,27 +73,5 @@ export async function callBarryTools(request: BarryToolsRequest): Promise<BarryO
   });
 
   if (error) throw new Error(error.message || 'Barry Tools unavailable');
-
-  // Normalise manual references — barry-tools returns a lighter shape
-  const rawRefs: Array<{ page_number: number; storage_url: string; title?: string }> =
-    data.manualReferences ?? [];
-
-  const manualReferences: ManualReference[] = rawRefs.map(r => ({
-    type: 'manual',
-    title: r.title ?? 'U435 Workshop Manual',
-    page_number: r.page_number,
-    original_page: r.page_number,
-    pdf_page: r.page_number,
-    storage_url: r.storage_url,
-    manual_type: 'manual',
-  }));
-
-  return {
-    content: data.content ?? '',
-    manualReferences,
-    knowledgeMode: data.knowledgeMode ?? 'tool_use',
-    searchResultCount: data.searchResultCount ?? 0,
-    skill_chain: data.skill_chain ?? [],
-    execution_time_ms: data.execution_time_ms,
-  };
+  return normaliseBarryToolsResponse(data ?? {});
 }


### PR DESCRIPTION
### Motivation
- Ensure the frontend receives a stable, defensive response shape from `barry-tools` and avoid duplicate manual citations leaking into the UI.
- Centralise response mapping so contract changes are easy to test and maintain.
- Provide regression coverage for mapping and deduplication behavior.

### Description
- Extracted a reusable adapter `normaliseBarryToolsResponse` and supporting types (`BarryToolsResponse`, `BarryToolsManualReference`) in `src/services/openclaw/barryToolsService.ts` to normalise the edge function response into the existing `BarryOpenClawResponse` shape.
- Added deduplication of manual references (keyed by `page_number|storage_url`) and safe defaults for missing fields (`content`, `knowledgeMode`, `searchResultCount`, `skill_chain`).
- Updated `callBarryTools` to return the result of `normaliseBarryToolsResponse` for consistent mapping.
- Added unit tests `src/__tests__/unit/services/barryToolsService.test.ts` that validate contract mapping and deduplication/default behavior.

### Testing
- Ran `npm run test -- src/__tests__/unit/services/barryToolsService.test.ts`, which executed the two new tests and they passed.
- Ran `npx eslint src/services/openclaw/barryToolsService.ts src/__tests__/unit/services/barryToolsService.test.ts`, which completed with no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda80b06d0832396fa8d145ccb1786)